### PR TITLE
Fix panic when trying to validate a JWT with unsupported content

### DIFF
--- a/jwt_test.go
+++ b/jwt_test.go
@@ -134,6 +134,18 @@ func TestValidation(t *testing.T) {
 		t.Fatalf("Validating succeded with invalid public key")
 	}
 
+	// Check that validation succeeds with unsupported content
+	token = JWT{Header{"JWT", "ed25519"}, "Hello world!", nil}
+	err = token.Validate(publicKey)
+	if err != nil {
+		t.Fatalf("Validation with unsupported content failed instead of ignoring content: %s", err.Error())
+	}
+	token = JWT{Header{"JWT", "ed25519"}, 1234567890, nil}
+	err = token.Validate(publicKey)
+	if err != nil {
+		t.Fatalf("Validation with unsupported content failed instead of ignoring content: %s", err.Error())
+	}
+
 	// Check validation of expiry
 	expired := make(map[string]interface{})
 	expired["exp"] = time.Now().Add(-10 * time.Minute).UTC().Unix()

--- a/validate.go
+++ b/validate.go
@@ -36,15 +36,16 @@ func (jwt *JWT) Validate(key ed25519.PublicKey) error {
 	}
 
 	// Validate expiry and not before if they exist
-	m := jwt.Content.(map[string]interface{})
-	if exp, ok := m["exp"].(float64); ok {
-		if time.Unix(int64(math.Round(exp)), 0).Before(time.Now()) {
-			return errors.New("jwt has expired")
+	if m, ok := jwt.Content.(map[string]interface{}); ok {
+		if exp, ok := m["exp"].(float64); ok {
+			if time.Unix(int64(math.Round(exp)), 0).Before(time.Now()) {
+				return errors.New("jwt has expired")
+			}
 		}
-	}
-	if nbf, ok := m["nbf"].(float64); ok {
-		if time.Unix(int64(math.Round(nbf)), 0).After(time.Now()) {
-			return errors.New("jwt is not valid, yet")
+		if nbf, ok := m["nbf"].(float64); ok {
+			if time.Unix(int64(math.Round(nbf)), 0).After(time.Now()) {
+				return errors.New("jwt is not valid, yet")
+			}
 		}
 	}
 


### PR DESCRIPTION
Fixing an issue with type casting a JWT with unsupported content (string, int, bool, ...).

Fixes #3 