### PR TITLE
Add test for struct token validation issue

### DIFF
--- a/jwt_test.go
+++ b/jwt_test.go
@@ -156,4 +156,30 @@ func TestValidation(t *testing.T) {
 	if err == nil {
 		t.Fatal("JSON encoder accepted function")
 	}
+
+	// Check validation for a struct
+	testStruct := struct {
+		Test bool
+		Data int
+	}{
+		true,
+		42,
+	}
+	structToken := JWT{Header{Typ: "JWT", Alg: "EdDSA"}, testStruct, nil}
+	err = structToken.Validate(publicKey)
+	if err != nil {
+		t.Errorf("Failed to validate a token generated using a struct: %s", err.Error())
+	}
+	encodedStructToken, err := structToken.Encode()
+	if err != nil {
+		t.Errorf("Failed to encode struct token: %s", err.Error())
+	}
+	decodedStructToken, err := Decode(string(encodedStructToken))
+	if err != nil {
+		t.Errorf("Failed to decode struct token: %s", err.Error())
+	}
+	err = decodedStructToken.Validate(publicKey)
+	if err != nil {
+		t.Errorf("Failed to validate decoded struct token: %s", err.Error())
+	}
 }

--- a/jwt_test.go
+++ b/jwt_test.go
@@ -159,11 +159,11 @@ func TestValidation(t *testing.T) {
 
 	// Check validation for a struct
 	testStruct := struct {
-		Test bool
 		Data int
+		Test bool
 	}{
-		true,
 		42,
+		true,
 	}
 	structToken := JWT{Header{Typ: "JWT", Alg: "EdDSA"}, testStruct, nil}
 	err = structToken.Validate(publicKey)

--- a/types.go
+++ b/types.go
@@ -8,7 +8,7 @@ type Header struct {
 	Jku string `json:"jku,omitempty"`
 }
 
-// JWT contains the header and content of a JSON web token as well booleans indicating the validity of the token
+// JWT contains the header and content of a JSON web token as well as the decoded hash
 type JWT struct {
 	Header  Header
 	Content interface{}

--- a/validate.go
+++ b/validate.go
@@ -16,7 +16,7 @@ func (jwt *JWT) Validate(key ed25519.PublicKey) error {
 		return errors.New("key is not a valid public key")
 	}
 	// Check token type and algorithm
-	if jwt.Header.Typ != "JWT" { // Check could be moved to decoding as other tokens should not be decoded
+	if jwt.Header.Typ != "JWT" {
 		return errors.New("header indicates token is not JWT")
 	}
 	if jwt.Header.Alg != "EdDSA" {


### PR DESCRIPTION
As discussed in issue #7 trying to validate a token that has a struct as content can fail. This is caused by Go ordering the map alphabetically when decoding the token. See the issue for details.